### PR TITLE
Fix verify_celery timeout type

### DIFF
--- a/NMTK_apps/NMTK_server/management/commands/verify_celery.py
+++ b/NMTK_apps/NMTK_server/management/commands/verify_celery.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
                             default=False,
                             help='Email the admins on error..')
         parser.add_argument('--timeout',
-                            type='int',
+                            type=int,
                             action='store',
                             dest='timeout',
                             default=600,

--- a/NMTK_apps/NMTK_server/management/commands/verify_celery.py
+++ b/NMTK_apps/NMTK_server/management/commands/verify_celery.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand, CommandError
-from optparse import make_option
 import datetime
 from NMTK_server import tasks
 from django.conf import settings


### PR DESCRIPTION
Fixes #4 

The "type" must be a reference to a type, not a string.
When a string, verify_celery fails with `ValueError: 'int' is not callable`