### PR TITLE
Ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ conf/*.key
 lets_encrypt/*.key
 lets_encrypt/*.csr
 lets_encrypty/acme-tiny
+
+# Ignore Mac filesystem-generated file
+.DS_Store


### PR DESCRIPTION
Developing on macOS, these files are occasionally generated and are ideally ignored.